### PR TITLE
Remove group_vars, fix ansible-lint warning

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -1,2 +1,0 @@
----
-ansible_tmp_dir: .ansible/tmp

--- a/roles/hubot/tasks/main.yaml
+++ b/roles/hubot/tasks/main.yaml
@@ -29,6 +29,8 @@
     become_user: hubot
     notify:
       - restart hubot
+    tags:
+      - skip_ansible_lint
 
   - name: install hubot configuration
     template:

--- a/roles/hubot/tasks/main.yaml
+++ b/roles/hubot/tasks/main.yaml
@@ -25,12 +25,10 @@
   - name: install hubot packages
     npm:
       path: /home/hubot/hubot
-      state: latest
+      state: present
     become_user: hubot
     notify:
       - restart hubot
-    tags:
-      - skip_ansible_lint
 
   - name: install hubot configuration
     template:


### PR DESCRIPTION
The latest ansible-lint complained about installing latest package, however, @magical mentioned currently we have to install the latest hubot packages for now. Therefore, I add a tag to ignore this ansible-lint warning, so that the Jenkins ansible-lint job won't failed just for now.