### PR TITLE
Add openjdk-8 role

### DIFF
--- a/roles/openjdk-7/tasks/main.yml
+++ b/roles/openjdk-7/tasks/main.yml
@@ -1,10 +1,10 @@
 ---
-  - name: install OpenJDK 7
+  - name: install OpenJDK 7 (CentOS)
     yum:
       name: java-1.7.0-openjdk-devel
     when: ansible_distribution == 'CentOS'
 
-  - name: install OpenJDK 7
+  - name: install OpenJDK 7 (Debian)
     apt:
       name: openjdk-7-jdk
       update_cache: yes

--- a/roles/openjdk-8/defaults/main.yml
+++ b/roles/openjdk-8/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+  java8_home: /usr/lib/jvm/java-1.8.0-openjdk-amd64

--- a/roles/openjdk-8/tasks/main.yml
+++ b/roles/openjdk-8/tasks/main.yml
@@ -1,0 +1,17 @@
+---
+  - name: install OpenJDK 8 (CentOS)
+    yum:
+      name: java-1.8.0-openjdk-devel
+    when: ansible_distribution == 'CentOS'
+
+  - name: add backports repo (Debian Jessie)
+    apt_repository:
+      repo: 'deb http://ftp.debian.org/debian jessie-backports main'
+      state: present
+    when: ansible_distribution == 'Debian' and ansible_distribution_release == 'jessie'
+
+  - name: install OpenJDK 8 (Debian)
+    apt:
+      name: openjdk-8-jdk
+      update_cache: yes
+    when: ansible_distribution == 'Debian'


### PR DESCRIPTION
ECSOPS-106

Tested with Debian Jessie and CentOS 7.2, using the following vagrant
boxes:

https://atlas.hashicorp.com/debian/boxes/contrib-jessie64/versions/8.4.0
https://atlas.hashicorp.com/centos/boxes/7/versions/1610.01

Note that the java8_home variable, like the java_home variable before
it, is only valid on Debian.