### PR TITLE
pip: fix installation under CentOS 6.8

### DIFF
--- a/roles/pip/tasks/main.yml
+++ b/roles/pip/tasks/main.yml
@@ -1,25 +1,17 @@
 ---
-  - name: Add EPEL repository
-    yum_repository:
-      name: EPEL
-      description: EPEL yum repo
-      baseurl: http://download.fedoraproject.org/pub/epel/$releasever/$basearch/
-      gpgkey: /etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-6
-    when: ansible_distribution == "CentOS" and ansible_distribution_major_version == "6"
-
-  - name: install EPEL
+  - name: add EPEL repository (CentOS)
     yum:
       name: epel-release
-    when: ansible_distribution == "CentOS" and ansible_distribution_major_version == "7"
+    when: ansible_distribution == "CentOS"
 
-  - name: install pip
+  - name: install pip (CentOS)
     yum:
       name: python-pip
       state: installed
       update_cache: yes
     when: ansible_distribution == 'CentOS'
 
-  - name: install pip
+  - name: install pip (Debian)
     apt:
       name: python-pip
       update_cache: yes


### PR DESCRIPTION
ECSOPS-109

It seems the EPEL repository wasn't getting configured correctly on
CentOS 6.8 for whatever reason, causing the python-pip install to fail
because the package could not be found. The epel-release package seems
to exist on 6.x, so just use it instead of attempting to add the EPEL
repository manually. Not sure why we were only using it for 7.x.

Tested on CentOS 6.7 and 6.8.