### PR TITLE
openjdk-8: update ca-certificates-java when installing on Debian Jessie

### DIFF
--- a/roles/openjdk-8/tasks/main.yml
+++ b/roles/openjdk-8/tasks/main.yml
@@ -10,6 +10,14 @@
       state: present
     when: ansible_distribution == 'Debian' and ansible_distribution_release == 'jessie'
 
+  - name: update ca-certificates-java (Debian Jessie)
+    apt:
+      name: ca-certificates-java
+      default_release: jessie-backports
+      state: latest
+      update_cache: yes
+    when: ansible_distribution == 'Debian' and ansible_distribution_release == 'jessie'
+
   - name: install OpenJDK 8 (Debian)
     apt:
       name: openjdk-8-jdk


### PR DESCRIPTION
ECSPCS-116

The latest version of openjdk-8 from jessie-backports is
incompatible with outdated version of ca-certificates-java which
comes with Debian Jessie, so we need to install an updated version
from jessie-backports.

We need to specify state=latest or else the package will not be
updated, since an old version is already installed. We need to
specify default_release=jessie-backports or else the package will
not be updated, since apt prefers packages from the main repo and
will only install packages from the backports repo if explicitly
asked.