### PR TITLE
dropwizard-api: read environment variables before launching

### DIFF
--- a/roles/dropwizard-api/README.md
+++ b/roles/dropwizard-api/README.md
@@ -9,6 +9,14 @@ The general process of deploying an API is
    /apis/config/API.yaml is present. Can either be installed
    ahead of time or copied along with the jar
 
+3. Write environment variables to /apis/env/API.env, in the form
+
+        PORT=8080
+        USER=admin
+        PASSWORD=!@#$^*"'
+
+    etc. No quoting is necessary.
+
 3. Run /apis/jenkins-run.sh API
 
 ... where API stands for the name of the api.

--- a/roles/dropwizard-api/README.md
+++ b/roles/dropwizard-api/README.md
@@ -11,11 +11,13 @@ The general process of deploying an API is
 
 3. Write environment variables to /apis/env/API.env, in the form
 
+        # This line is a comment
         PORT=8080
         USER=admin
         PASSWORD=!@#$^*"'
 
-    etc. No quoting is necessary.
+    etc. No quoting is necessary. Variables must start with an uppercase
+    letter, and setting PATH is not allowed.
 
 3. Run /apis/jenkins-run.sh API
 

--- a/roles/dropwizard-api/defaults/main.yml
+++ b/roles/dropwizard-api/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
 # put the hashed password here, see more detail: http://docs.ansible.com/ansible/faq.html#how-do-i-generate-crypted-passwords-for-the-user-module
-user_password: password
+user_password: ""

--- a/roles/dropwizard-api/files/supervisord-run.sh
+++ b/roles/dropwizard-api/files/supervisord-run.sh
@@ -12,7 +12,7 @@ name=$(basename "$(pwd)")
 node="$(whoami)@$(hostname):$name"
 archive=$(ls "$name"-*-all.jar | sort | tail -1)
 config=/apis/config/$name.yaml
-env=/apis/apis/$name/environment.env
+env=/apis/env/$name.env
 
 if [ ! -e "$config" ]; then
     config=/apis/apis/$name/configuration.yaml

--- a/roles/dropwizard-api/files/supervisord-run.sh
+++ b/roles/dropwizard-api/files/supervisord-run.sh
@@ -25,11 +25,15 @@ fi
 if [ -r "$env" ]; then
     while IFS='\n' read -r line; do
         case "$line" in
+        \#*|'')
+            ;; # comment
         PATH=*)
-            ;;
+            ;; # not allowed
         [A-Z]*=*)
             export "$line"
             ;;
+        *)
+            echo "ignoring invalid line \"$line\""
         esac
     done <"$env"
 fi

--- a/roles/dropwizard-api/files/supervisord-run.sh
+++ b/roles/dropwizard-api/files/supervisord-run.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # supervisord-run.sh - starts an api in the foreground
 # usually run indirectly by a supervisord job
 # it is not meant to be called directly
@@ -12,9 +12,26 @@ name=$(basename "$(pwd)")
 node="$(whoami)@$(hostname):$name"
 archive=$(ls "$name"-*-all.jar | sort | tail -1)
 config=/apis/config/$name.yaml
+env=/apis/apis/$name/environment.env
 
 if [ ! -e "$config" ]; then
     config=/apis/apis/$name/configuration.yaml
+fi
+
+# Read environment file
+# Only allow variables that start with a capital letter
+# to prevent them from overwriting our own variables.
+# Don't allow overwriting the PATH variable.
+if [ -r "$env" ]; then
+    while IFS='\n' read -r line; do
+        case "$line" in
+        PATH=*)
+            ;;
+        [A-Z]*=*)
+            export "$line"
+            ;;
+        esac
+    done <"$env"
 fi
 
 if [ -e /apis/appd/javaagent.jar ]

--- a/roles/dropwizard-api/tasks/main.yml
+++ b/roles/dropwizard-api/tasks/main.yml
@@ -9,7 +9,7 @@
   - name: check if modify user password or not
     fail:
       msg: "Please enter a new password for osu_apis!"
-    when: user_password == "password"
+    when: user_password == ""
 
   - name: create user osu_apis
     user:


### PR DESCRIPTION
ECSOPS-67

ECSOPS-103 created a common repo for config files. In order to keep
credentials off of github, it was decided to set them with environment
variables. This commit adds support for loading environment variables
from a file before launching an API.

If the startup script finds a file named environment.env in the
api directory /apis/apis/$name, then it will scan it for lines of the
form NAME=value and export them to the environment (NAME must start
with an uppercase character).