### PR TITLE
Stop contianer first then remove

### DIFF
--- a/roles/dropwizard-api/files/start-container.j2
+++ b/roles/dropwizard-api/files/start-container.j2
@@ -38,7 +38,8 @@ gid="$(id -g {{ user }})"
 # Stop and destroy container if it's already running
 if [[ "$(docker ps -aq -f name=$api)" ]]; then
     echo "Stop existing container"
-    docker rm -f "$api"
+    docker stop "$api"
+    docker rm "$api"
 
     # Sometimes docker will still think a container exists after doing "docker rm"
     # Pause the script for a few seconds before creating the container again


### PR DESCRIPTION
We ran into the issue that docker complained unable to remove filesystem probably due to `docker rm -f` causes a time delay. As a temp fix, we are now performing `docker stop && docker rm $api` instead of `docker rm -f`. 

It seems like this has been fixed: https://github.com/moby/moby/pull/34573 . We should work on this by upgrading docker in next sprint.