### PR TITLE
bump ansible version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@ Collect Ansible roles for automatical deployment.
 
 ### Requirements
 ----------------
-1. [Ansible (version 2.1)](https://github.com/ansible/ansible) should be [installed](http://docs.ansible.com/ansible/intro_installation.html) first. In addition, we should also prepare an Ansible `inventory` file to run this playbook.
+1. [Ansible (version 2.4)](https://github.com/ansible/ansible) should be [installed](http://docs.ansible.com/ansible/intro_installation.html) first.
+In addition, we should also prepare an Ansible `inventory` file to run this playbook.
 
 	**Inventory File Example:**
 	```


### PR DESCRIPTION
Prior to ansible 2.4, ansible required an old version of docker-py
which conflicts with docker-compose. (This is because docker-py 2.0 and
later renamed a class that ansible depended on).

The error was something like this:

    fatal: [ci]: FAILED! => {"changed": false, "failed": true, "msg": "Failed to import docker-py - cannot import name Client. Try `pip install docker-py`"}

See e.g.,

    https://github.com/ansible/ansible/issues/20380
    https://github.com/ansible/ansible/issues/20492
    https://stackoverflow.com/questions/38181433/ansible-cannot-import-docker-py-even-though-it-is-installed

Ansible 2.3 was updated to (mostly) be compatible with newer versions of the
docker-py library, and ansible 2.4 improved support further.

    https://github.com/ansible/ansible/commit/e2a1ce2916e9b87fe1ad4a1011c04ef8d2faf046
    https://github.com/ansible/ansible/commit/51a9875cfd10bb906bf8329bb986b69900a26dd8

Bump the version we say that we require so that nobody else has to
run into this error.