### PR TITLE
upgrade version, don't checkout for docker selinux

### DIFF
--- a/roles/docker/defaults/main.yml
+++ b/roles/docker/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 debian_apt_repo: https://download.docker.com/linux/debian
 
-docker_ce_version: 17.12.0
+docker_ce_version: 17.12.1
 debian_docker_ce_version: "{{ docker_ce_version }}~ce-0~debian"
 centos_docker_ce_version: "{{ docker_ce_version }}.ce"

--- a/roles/docker/tasks/centos.yml
+++ b/roles/docker/tasks/centos.yml
@@ -7,7 +7,6 @@
       - docker
       - docker-common
       - docker-engine
-      - docker-selinux
 
   - name: install required packages
     yum:


### PR DESCRIPTION
Removing docker-selinux caused yum to remove docker-ce as well. Since we never installed docker-selinux on our hosts, and removing it is causing issues, I'm removing the check to remove it.