### PR TITLE
don't always restart

### DIFF
--- a/roles/dropwizard-api/files/start-container.j2
+++ b/roles/dropwizard-api/files/start-container.j2
@@ -56,7 +56,7 @@ docker run \
     -d \
     --name "$api" \
     --label jar=$archive \
-    --restart always \
+    --restart on-failure:3 \
     --user="$uid:$gid" \
     --workdir="$api_path" \
     --env-file "$env" \


### PR DESCRIPTION
restarting indefinitely has no benefit here, since if the application fails to start, it's due to an underlying issue and not something that's fixable by restarting the API forever. Instead, let's restart a few times.