### PR TITLE
change docker image

### DIFF
--- a/roles/elasticsearch/tasks/main.yml
+++ b/roles/elasticsearch/tasks/main.yml
@@ -2,6 +2,6 @@
   - name: start elasticsearch container
     docker_container:
       name: elasticsearch
-      image: "elasticsearch:{{ es_version }}"
+      image: "docker.elastic.co/elasticsearch/elasticsearch:{{ es_version }}"
       restart_policy: always
       network_mode: host

--- a/roles/elasticsearch/tasks/main.yml
+++ b/roles/elasticsearch/tasks/main.yml
@@ -1,4 +1,5 @@
 ---
+  # https://www.elastic.co/guide/en/elasticsearch/reference/current/vm-max-map-count.html
   - name: set vm.max_map_count
     command: sysctl -w vm.max_map_count=262144
 

--- a/roles/elasticsearch/tasks/main.yml
+++ b/roles/elasticsearch/tasks/main.yml
@@ -1,7 +1,17 @@
 ---
+  - name: set vm.max_map_count
+    command: sysctl -w vm.max_map_count=262144
+
   - name: start elasticsearch container
     docker_container:
       name: elasticsearch
       image: "docker.elastic.co/elasticsearch/elasticsearch:{{ es_version }}"
       restart_policy: always
       network_mode: host
+      env:
+        bootstrap.memory_lock: "true"
+        ES_JAVA_OPTS: "-Xms512m -Xmx512m"
+      ulimits:
+        - memlock:-1:-1
+      volumes:
+        - /usr/share/elasticsearch/data


### PR DESCRIPTION
the old 'elasticsearch' image was deprecated in favor of the official image, which is here:

https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html