### PR TITLE
use 100mb heap max

### DIFF
--- a/roles/api-environment/templates/dropwizard-api/start-container.sh.j2
+++ b/roles/api-environment/templates/dropwizard-api/start-container.sh.j2
@@ -50,7 +50,7 @@ fi
 
 echo "Start container"
 
-java_command="java -jar $archive server $config"
+java_command="java -Xmx100m -jar $archive server $config"
 
 docker run \
     -d \


### PR DESCRIPTION
This commit adds an argument when starting dropwizard APIs to set the heap max to 100mb.

Since we run our APIs, in containers, The default behavior, if no max heap is specified, is that the JVM uses one-fourth of all memory available for the host OS due to a default internal garbage collection (GC) ergonomic algorithm. Source: https://dzone.com/articles/java-ram-usage-in-containers-top-5-tips-not-to-los