### PR TITLE
CO-1230: Use healthcheck endpoint for docker health command

### DIFF
--- a/roles/api-environment/templates/dropwizard-api/start-container.sh.j2
+++ b/roles/api-environment/templates/dropwizard-api/start-container.sh.j2
@@ -61,7 +61,7 @@ docker run \
     --workdir="$api_path" \
     --env-file "$env" \
     --network host \
-    --health-cmd='curl -k -fsS --user $USER:$PASSWD https://localhost:$PORT/api/v1' \
+    --health-cmd='curl -k -fsS https://localhost:$ADMIN_PORT/healthcheck' \
     --health-interval=1m \
     --volume $keytool_path/server.keystore:$keytool_path/server.keystore:ro \
     --volume $keytool_path/server.truststore:$keytool_path/server.truststore:ro \

--- a/roles/elasticsearch/tasks/main.yml
+++ b/roles/elasticsearch/tasks/main.yml
@@ -14,6 +14,7 @@
       env:
         bootstrap.memory_lock: "true"
         ES_JAVA_OPTS: "-Xms512m -Xmx512m"
+        xpack.security.enabled: "false"
       ulimits:
         - memlock:-1:-1
       volumes:


### PR DESCRIPTION
This changes the docker health check command to send a request to https://localhost:$ADMIN_PORT/healthcheck to decide the health of the container.