### PR TITLE
ECSOPS-101 Set mysql-db to be case insensitive

### DIFF
--- a/roles/mysql-server/tasks/main.yml
+++ b/roles/mysql-server/tasks/main.yml
@@ -4,6 +4,7 @@
       name: mysql-db
       image: "mysql:5.7"
       restart_policy: always
+      command: "--lower_case_table_names=1"
       env:
         MYSQL_ROOT_PASSWORD: "{{ mysql_root_password }}"
       volumes:


### PR DESCRIPTION
Changing the `lower_case_table_names` variable on a running db can cause issues and thus should be tested for all jobs using this db. This is, however, required for EvalS unit tests. I tested the vault jobs both without re-inserting data and with fresh data and both worked. If other jobs are using this db they should be tested as well but I don't know of any.