### PR TITLE
ECSOPS-240 Install missing package for Debian Stretch

### DIFF
--- a/roles/openjdk-8/tasks/main.yml
+++ b/roles/openjdk-8/tasks/main.yml
@@ -30,6 +30,12 @@
     tags:
       - skip_ansible_lint
 
+  - name: install OpenJDK 8 headless (Debian Stretch)
+    apt:
+      name: openjdk-8-jdk-headless
+      update_cache: yes
+    when: ansible_distribution == 'Debian' and ansible_distribution_release == 'stretch'
+
   - name: install OpenJDK 8 (Debian)
     apt:
       name: openjdk-8-jdk


### PR DESCRIPTION
To installed openjdk 8 in Debian 9, we need to unstall `openjdk-8-jdk-headless` first.